### PR TITLE
404ページの作成。リダイレクトの追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,19 @@
   from = "/salon-support"
   to = "/service"
   status = 301
+
+[[redirects]]
+  from = "/company-data/"
+  to = "/company"
+  status = 301
+
+[[redirects]]
+  from = "/hpservice-terms/"
+  to = "/service"
+  status = 301
+
+[[redirects]]
+  from = "/personal-info/"
+  to = "/privacy"
+  status = 301
+

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="hero is-medium">
+    <div class="hero-body">
+      <div class="container center-text">
+        <h1>
+          指定されたページが見つかりませんでした。
+        </h1>
+        <nuxt-link to="/">トップページ</nuxt-link>に戻る。
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  head() {
+    return {
+      title: 'エラー'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>


### PR DESCRIPTION
### 概要
* 404ページの作成とリダイレクトの追加

### 目的
* 404ページがnetlifyのデフォルトになっていてユーザビリティが悪い
* リダイレクトが不十分で404ページが表示される

### 対応内容
* 404ページの作成とリダイレクトの追加