### PR TITLE
【WIP】クエリパラメータでカテゴリの絞り込みする実装

### DIFF
--- a/components/pages/common/TheColumnList.vue
+++ b/components/pages/common/TheColumnList.vue
@@ -15,7 +15,7 @@
               {{ item.display_at | dayjs }}
               <br>
               <p class="column-store">{{ item.store }}</p>
-              <nuxt-link :to="'/column/'">
+              <nuxt-link :to="'/column?filters=' + item.label.id">
                 <span :class="'tag ' + item.label.color_class ">
                   {{ item.label.label }}
                 </span>

--- a/components/pages/common/TheColumnList.vue
+++ b/components/pages/common/TheColumnList.vue
@@ -15,9 +15,11 @@
               {{ item.display_at | dayjs }}
               <br>
               <p class="column-store">{{ item.store }}</p>
-              <span class="tag is-primary">
-                {{ item.label.label }}
-              </span>
+              <nuxt-link :to="'/column/'">
+                <span :class="'tag ' + item.label.color_class ">
+                  {{ item.label.label }}
+                </span>
+              </nuxt-link>
             </div>
           </div>
         </nuxt-link>

--- a/lib/cms.js
+++ b/lib/cms.js
@@ -9,8 +9,8 @@ const NEWS_PAGE = 'news'
  * @param limit ページリミット 
  * @param offset オフセット
  */
-export async function fetchCmsListDataColumn(limit = 10, offset = 0) {
-  return fetchCmsListData(COLUMN_PAGE, limit, offset)
+export async function fetchCmsListDataColumn(limit = 10, offset = 0, filters) {
+  return fetchCmsListData(COLUMN_PAGE, limit, offset, filters)
 }
 
 /*
@@ -57,12 +57,20 @@ export async function routing() {
  * @param limit ページリミット 
  * @param offset オフセット
  */
-async function fetchCmsListData(pageName, limit = 10, offset = 0) {
+async function fetchCmsListData(
+  pageName,
+  limit = 10,
+  offset = 0,
+  filters = null
+) {
+  if (filters) {
+    filters = `&filters=label[equals]` + filters
+  }
   const { data } = await axios
     .get(
       `${
         process.env.microCmsApiDomain
-      }/${API_VERSION}/${pageName}?limit=${limit}&offset=${offset}`,
+      }/${API_VERSION}/${pageName}?limit=${limit}&offset=${offset}${filters}`,
       {
         headers: { 'X-API-kEY': process.env.microCmsApiKey }
       }

--- a/pages/column/index.vue
+++ b/pages/column/index.vue
@@ -15,7 +15,8 @@ import { fetchCmsListDataColumn } from '~/lib/cms'
 export default {
   components: {
     TheHeroTitle,
-    TheColumnList
+    TheColumnList,
+    watchQuery: ['filters']
   },
   head() {
     return {
@@ -61,8 +62,8 @@ export default {
     }
   },
 
-  asyncData() {
-    return fetchCmsListDataColumn()
+  asyncData({ query }) {
+    return fetchCmsListDataColumn(null, null, query.filters)
   }
 }
 </script>


### PR DESCRIPTION
### 概要
 - クエリパラメータでカテゴリの絞り込みする実装
<img width="836" alt="最近の活動・コラム" src="https://user-images.githubusercontent.com/36440333/79891658-48a68c00-843c-11ea-9d52-b69efe52c77d.png">


### 対応内容
- カテゴリにリンクを動的に割り当てる（MicroCMSで取得したカテゴリID）
- そのリンクにクエリパラメータ（filters=カテゴリID）を仕込み、アクセスするとAPIに通信が走り、コラムの再取得＋画面の再描画が走る