### PR TITLE
内部統制支援の活動実績の追加

### DIFF
--- a/lib/cms-fetch.js
+++ b/lib/cms-fetch.js
@@ -1,0 +1,74 @@
+require('dotenv').config()
+import axios from 'axios'
+
+const API_VERSION = 'v1'
+
+/*
+* microCMSから一覧データを取得
+* @param pageName 取得するページ名
+* @param limit ページリミット 
+* @param offset オフセット
+*/
+export async function fetchCmsListData(pageName, limit = 10, offset = 0) {
+  const { data } = await axios
+    .get(
+      `${
+        process.env.microCmsApiDomain
+      }/${API_VERSION}/${pageName}?limit=${limit}&offset=${offset}`,
+      {
+        headers: { 'X-API-KEY': process.env.microCmsApiKey }
+      }
+    )
+    .catch(err => {
+      console.log(err.response)
+      return err.response
+    })
+  return {
+    listData: data.contents
+  }
+}
+
+/*
+  * microCMSから一覧データをidベースで取得
+  * @param pageName 取得するページ名
+  * @param ids 取得するidの配列
+  * @param limit ページリミット 
+  */
+export async function fetchCmsListDataByIds(pageName, ids) {
+  const { data } = await axios
+    .get(
+      `${
+        process.env.microCmsApiDomain
+      }/${API_VERSION}/${pageName}?ids=${ids.join(',')}`,
+      {
+        headers: { 'X-API-KEY': process.env.microCmsApiKey }
+      }
+    )
+    .catch(err => {
+      console.log(err.response)
+      return err.response
+    })
+  return {
+    listData: data.contents
+  }
+}
+
+/*
+  * microCMSからページ名とIDを指定してデータを取得
+  * @param pageName 取得するページ名
+  * @param id ID
+  */
+export async function fetchCmsData(pageName, id) {
+  const { data } = await axios
+    .get(`${process.env.microCmsApiDomain}/${API_VERSION}/${pageName}/${id}`, {
+      headers: { 'X-API-KEY': process.env.microCmsApiKey }
+    })
+    .catch(err => {
+      console.log('fetchCmsDataError')
+      console.log(err.response)
+      return err.response
+    })
+  return {
+    data: data
+  }
+}

--- a/lib/cms.js
+++ b/lib/cms.js
@@ -1,6 +1,10 @@
 require('dotenv').config()
-import axios from 'axios'
-const API_VERSION = 'v1'
+import {
+  fetchCmsListData,
+  fetchCmsListDataByIds,
+  fetchCmsData
+} from './cms-fetch'
+
 const COLUMN_PAGE = 'column'
 const NEWS_PAGE = 'news'
 const CASE_PAGE = 'cases'
@@ -11,7 +15,7 @@ const CASE_PAGE = 'cases'
  * @param offset オフセット
  */
 export async function fetchCmsListDataCase(limit = 10, offset = 0) {
-  return fetchCmsListData(CASE_PAGE, limit, offset)
+  return await fetchCmsListData(CASE_PAGE, limit, offset)
 }
 
 /*
@@ -20,7 +24,7 @@ export async function fetchCmsListDataCase(limit = 10, offset = 0) {
  * @param offset オフセット
  */
 export async function fetchCmsListDataColumn(limit = 10, offset = 0) {
-  return fetchCmsListData(COLUMN_PAGE, limit, offset)
+  return await fetchCmsListData(COLUMN_PAGE, limit, offset)
 }
 
 /*
@@ -29,7 +33,11 @@ export async function fetchCmsListDataColumn(limit = 10, offset = 0) {
  * @param offset オフセット
  */
 export async function fetchCmsListDataNews(limit = 10, offset = 0) {
-  return fetchCmsListData(NEWS_PAGE, limit, offset)
+  return await fetchCmsListData(NEWS_PAGE, limit, offset)
+}
+
+export async function fetchCmsListDataCaseByIds(ids) {
+  return await fetchCmsListDataByIds(CASE_PAGE, ids)
 }
 
 /*
@@ -37,7 +45,7 @@ export async function fetchCmsListDataNews(limit = 10, offset = 0) {
  * @param id ID
  */
 export async function fetchCmsDataCase(id) {
-  return fetchCmsData(CASE_PAGE, id)
+  return await fetchCmsData(CASE_PAGE, id)
 }
 
 /*
@@ -45,7 +53,7 @@ export async function fetchCmsDataCase(id) {
  * @param id ID
  */
 export async function fetchCmsDataColumn(id) {
-  return fetchCmsData(COLUMN_PAGE, id)
+  return await fetchCmsData(COLUMN_PAGE, id)
 }
 
 /*
@@ -53,7 +61,7 @@ export async function fetchCmsDataColumn(id) {
    * @param id ID
    */
 export async function fetchCmsDataNews(id) {
-  return fetchCmsData(NEWS_PAGE, id)
+  return await fetchCmsData(NEWS_PAGE, id)
 }
 
 /*
@@ -61,55 +69,12 @@ export async function fetchCmsDataNews(id) {
  * @return array ページパス一覧
  */
 export async function routing() {
-  const columns = await fetchCmsListDataColumn()
-  const news = await fetchCmsListDataNews()
+  const columns = await fetchCmsListDataColumn(100)
+  const news = await fetchCmsListDataNews(100)
+  const cases = await fetchCmsListDataCase(100)
   return [
     ...columns.listData.map(entry => `/column/${entry.id}`),
-    ...news.listData.map(entry => `/news/${entry.id}`)
+    ...news.listData.map(entry => `/news/${entry.id}`),
+    ...cases.listData.map(entry => `/cases/${entry.id}`)
   ]
-}
-
-/*
- * microCMSから一覧データを取得
- * @param pageName 取得するページ名
- * @param limit ページリミット 
- * @param offset オフセット
- */
-async function fetchCmsListData(pageName, limit = 10, offset = 0) {
-  const { data } = await axios
-    .get(
-      `${
-        process.env.microCmsApiDomain
-      }/${API_VERSION}/${pageName}?limit=${limit}&offset=${offset}`,
-      {
-        headers: { 'X-API-kEY': process.env.microCmsApiKey }
-      }
-    )
-    .catch(err => {
-      console.log(err.response)
-      return err.response
-    })
-  return {
-    listData: data.contents
-  }
-}
-
-/*
- * microCMSからページ名とIDを指定してデータを取得
- * @param pageName 取得するページ名
- * @param id ID
- */
-async function fetchCmsData(pageName, id) {
-  const { data } = await axios
-    .get(`${process.env.microCmsApiDomain}/${API_VERSION}/${pageName}/${id}`, {
-      headers: { 'X-API-kEY': process.env.microCmsApiKey }
-    })
-    .catch(err => {
-      console.log('fetchCmsDataError')
-      console.log(err.response)
-      return err.response
-    })
-  return {
-    data: data
-  }
 }

--- a/pages/service/it-control.vue
+++ b/pages/service/it-control.vue
@@ -123,10 +123,12 @@
           <img :src="itControllExampleImage" class="it-control-examlpe-img" >
         </a>
       </section>
-      <!-- <section>
-        <the-sub-header text="内部統制支援実績" />
-        <the-case-list :cases="cases" />
-      </section> -->
+      <section>
+        <the-sub-header text="内部統制（ガバナンス）支援実績" />
+        <div class="case-list-wrapper">
+          <the-case-list :cases="cases" />
+        </div>
+      </section>
       <div class="contact-area">
         <the-contact />
       </div>
@@ -138,7 +140,7 @@
 </template>
 
 <script>
-import { fetchCmsListDataCase } from '~/lib/cms'
+import { fetchCmsListDataCaseByIds } from '~/lib/cms'
 import TheHeroTitle from '~/components/pages/common/TheHeroTitle.vue'
 import TheSubHeader from '~/components/pages/service/common/TheSubHeader.vue'
 import itControllImage from '~/assets/service/img/it-control.JPG'
@@ -160,7 +162,7 @@ export default {
     TheServiceLinks
   },
   async asyncData() {
-    const data = await fetchCmsListDataCase(3)
+    const data = await fetchCmsListDataCaseByIds(['innophys'])
     return { cases: data.listData }
   },
   computed: {
@@ -212,5 +214,9 @@ export default {
     max-width: 80%;
     margin-left: 10%;
   }
+}
+
+.case-list-wrapper {
+  margin-top: 2rem;
 }
 </style>


### PR DESCRIPTION
### 概要
- 内部統制支援の活動実績を追加

### 目的
- CV率向上のため

### 対応内容
- microCMSの記事をidベースで複数取得出来るように修正
- 取得処理のバグ修正
- 活動実績の表示