### PR TITLE
ディスクリプションタグなどの修正

### DIFF
--- a/assets/posts.scss
+++ b/assets/posts.scss
@@ -94,6 +94,9 @@
   /deep/ ol li {
     margin-left: 20px;
   }
+  /deep/ a {
+    word-wrap: break-word;
+  }
 }
 /deep/ .news-image img {
   display: none;

--- a/pages/cases/_id.vue
+++ b/pages/cases/_id.vue
@@ -64,7 +64,7 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: '株式会社エッグシステム 顧客インタビュー・事例紹介'
+          content: this.data.description
         },
         {
           hid: 'keywords',
@@ -86,7 +86,7 @@ export default {
         {
           hid: 'og:description',
           property: 'og:description',
-          content: '株式会社エッグシステム 顧客インタビュー・事例紹介'
+          content: this.data.description
         },
         {
           hid: 'og:url',

--- a/pages/cases/index.vue
+++ b/pages/cases/index.vue
@@ -63,7 +63,7 @@ export default {
   },
 
   asyncData() {
-    return fetchCmsListDataCase(23)
+    return fetchCmsListDataCase(100)
   }
 }
 </script>

--- a/pages/column/_id.vue
+++ b/pages/column/_id.vue
@@ -61,7 +61,7 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: '株式会社エッグシステム コラム'
+          content: this.data.description
         },
         {
           hid: 'keywords',
@@ -82,7 +82,7 @@ export default {
         {
           hid: 'og:description',
           property: 'og:description',
-          content: '株式会社エッグシステム コラム'
+          content: this.data.description
         },
         {
           hid: 'og:url',

--- a/pages/column/index.vue
+++ b/pages/column/index.vue
@@ -60,7 +60,7 @@ export default {
   },
 
   asyncData() {
-    return fetchCmsListDataColumn(23)
+    return fetchCmsListDataColumn(100)
   }
 }
 </script>

--- a/pages/news/_id.vue
+++ b/pages/news/_id.vue
@@ -64,7 +64,7 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: '株式会社エッグシステム コラム'
+          content: this.data.description
         },
         {
           hid: 'keywords',
@@ -85,7 +85,7 @@ export default {
         {
           hid: 'og:description',
           property: 'og:description',
-          content: '株式会社エッグシステム コラム'
+          content: this.data.description
         },
         {
           hid: 'og:url',

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -62,7 +62,7 @@ export default {
   },
 
   asyncData() {
-    return fetchCmsListDataNews(23)
+    return fetchCmsListDataNews(100)
   }
 }
 </script>


### PR DESCRIPTION
### 概要
- 各種、バグの修正

### 目的
- レイアウト崩れやSEO対策などのため

### 対応内容
- ディスクリプションタグをMicroCMSから取得する
- CMSから取得した記事にURLがあっても、レイアウトが崩れないようにする
    - ex) /news/20201105-media
- ページングがない不具合対策
    - 暫定対応で全表示させる