### PR TITLE
ヘッダーメニューの修正

### DIFF
--- a/components/layouts/Header.vue
+++ b/components/layouts/Header.vue
@@ -21,19 +21,11 @@
     <div :class="[isOpen ? 'is-active' : '']" class="navbar-menu" @click="menu()">
       <div class="navbar-end">
         <nuxt-link class="navbar-item" to="/about">
-          わたしたちについて
-        </nuxt-link>
-
-        <nuxt-link class="navbar-item" to="/about/consulting-engineer">
-          コンサルティングエンジニアとは
+          企業理念
         </nuxt-link>
 
         <nuxt-link class="navbar-item" to="/service">
           サービス
-        </nuxt-link>
-
-        <nuxt-link class="navbar-item" to="/member">
-          メンバー
         </nuxt-link>
 
         <nuxt-link class="navbar-item" to="/cases">

--- a/components/layouts/Header.vue
+++ b/components/layouts/Header.vue
@@ -21,7 +21,7 @@
     <div :class="[isOpen ? 'is-active' : '']" class="navbar-menu" @click="menu()">
       <div class="navbar-end">
         <nuxt-link class="navbar-item" to="/about">
-          企業理念
+          経営理念
         </nuxt-link>
 
         <nuxt-link class="navbar-item" to="/service">

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="content page-content">
-      <the-hero-title main-text="わたしたちについて" />
+      <the-hero-title main-text="企業理念" />
       <the-message class="end" />
       <section>
         <the-sub-header text="ロゴに込められた想い" />

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -34,7 +34,7 @@ export default {
   },
   head() {
     return {
-      title: 'わたしたちについて',
+      title: '企業理念',
       meta: [
         {
           hid: 'about-description',

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="content page-content">
-      <the-hero-title main-text="企業理念" />
+      <the-hero-title main-text="経営理念" />
       <the-message class="end" />
       <section>
         <the-sub-header text="ロゴに込められた想い" />
@@ -34,7 +34,7 @@ export default {
   },
   head() {
     return {
-      title: '企業理念',
+      title: '経営理念',
       meta: [
         {
           hid: 'about-description',


### PR DESCRIPTION
### 概要
- ヘッダーメニューが詰まっているので、修正する

### 目的
- デザイン改善のため

### 対応内容
- 「わたしたちについて」を「経営理念」に変更
- ヘッダーメニューから、「メンバー」「コンサルティングエンジニアについて」を削る